### PR TITLE
Mawu Task: fix footer navigation typing

### DIFF
--- a/apps/web/src/components/layout/SiteFooter.tsx
+++ b/apps/web/src/components/layout/SiteFooter.tsx
@@ -3,6 +3,10 @@ import { Link } from "react-router-dom";
 import { Body, Container, Heading } from "../../design-system";
 import { NewsletterSignup } from "../NewsletterSignup";
 
+type NavigationLink = { label: string } & ({ to: string } | { href: string });
+
+const isRouteLink = (link: NavigationLink): link is NavigationLink & { to: string } => "to" in link;
+
 const commitments = [
   "Community stewardship councils guide every investment.",
   "Transparent budgets and dashboards keep partners aligned.",
@@ -45,7 +49,8 @@ const navigationColumns = [
       { href: "https://instagram.com/mawufoundation", label: "Instagram" },
     ],
   },
-];
+// Using `satisfies` ensures TypeScript understands the discriminated union for href/to links.
+] satisfies Array<{ title: string; links: NavigationLink[] }>;
 
 export const SiteFooter = () => (
   <footer className="bg-ink-900 text-white">
@@ -104,7 +109,7 @@ export const SiteFooter = () => (
             <ul className="space-y-3 text-sm text-white/75">
               {column.links.map((link) => (
                 <li key={link.label}>
-                  {"to" in link ? (
+                  {isRouteLink(link) ? (
                     <Link className="transition hover:text-brand-200" to={link.to}>
                       {link.label}
                     </Link>

--- a/docs/update-log.md
+++ b/docs/update-log.md
@@ -1,3 +1,3 @@
-# Update Log – Mawu Task
+# Repository Sync Log
 
-- Synchronized local workspace with upstream branch `main` at commit `ee80b0e` ("moved-from-landing-v1"), ensuring the environment reflects the latest available code from GitHub.
+- Synced local `work` branch with upstream commit [`2c623cd`](https://github.com/woedy/mawu_foundation_super/commit/2c623cd3343f10e5fc85668a4f5ae06d7eedf151) (`vercel-push-v3`).


### PR DESCRIPTION
## Summary
- update the repository sync log to note alignment with upstream commit 2c623cd (vercel-push-v3)
- ensure footer navigation links use a discriminated union so React Router `Link` components always receive a defined `to` value during builds

## Testing
- npm run build --workspace @mawu/web

------
https://chatgpt.com/codex/tasks/task_e_68db858e076083268d7b73cb9e399b45