### PR TITLE
Configure Vercel deployment settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Run these from the repository root.
 
 ## Deployment
 - Deploy the Vite build output (`apps/web/dist`) to any static host such as Coolify, Netlify, or Vercel—no Express servers or Node backends are needed.
-- Follow the platform-specific docs for step-by-step guidance (the root `vercel.json` already configures the static build for
-  Vercel):
+- Follow the platform-specific docs for step-by-step guidance (the root `vercel.json` now pins the workspace commands, output
+  directory, and single-page-app fallback that Vercel needs to serve the static build correctly):
   - [`docs/deployment/vercel.md`](docs/deployment/vercel.md) for Vercel’s static hosting workflow.
   - [`docs/deployment/coolify.md`](docs/deployment/coolify.md) for a single-service Coolify setup.
 - If you set `VITE_ANALYTICS_DOMAIN`, ensure the host exposes the same domain so Plausible can receive events.

--- a/docs/deployment/vercel.md
+++ b/docs/deployment/vercel.md
@@ -20,8 +20,8 @@ This walkthrough publishes the Mawu Foundation investor demo as a fully static s
 1. In the Vercel dashboard click **Add New… → Project** and import this repository.
 2. When prompted for the **Framework Preset**, choose **Vite**.
 3. If you prefer configuring the project entirely from the repo, keep the **Root Directory** as the repository root—`vercel.json`
-   already instructs Vercel to install workspace dependencies, run `npm run build --workspace @mawu/web`, and publish the
-   static bundle from `apps/web/dist`.
+   now instructs Vercel to install workspace dependencies, run `npm run build --workspace @mawu/web`, publish the static bundle
+   from `apps/web/dist`, and rewrite deep links back to `index.html` so the single-page app router works on refresh.
 4. Alternatively, you can point the **Root Directory** to `apps/web` and keep the default Vite settings; both approaches build
    the same static output.
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "framework": "vite",
+  "installCommand": "npm install",
+  "buildCommand": "npm run build --workspace @mawu/web",
+  "devCommand": "npm run dev --workspace @mawu/web",
+  "outputDirectory": "apps/web/dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a root vercel.json so Vercel installs workspace deps, builds @mawu/web, and rewrites SPA routes
- update the README and Vercel deployment guide to document the new configuration details

## Testing
- npm run build --workspace @mawu/web

------
https://chatgpt.com/codex/tasks/task_e_68dba37e585c832693de1373e3bf6b05